### PR TITLE
Fix double usage of "/api/v1" in Kaleido API endpoint URL

### DIFF
--- a/node.js/app.js
+++ b/node.js/app.js
@@ -33,21 +33,33 @@ async function main() {
     const contract = network.getContract(chaincodeName);
 
     const isInit = prompt('Calling "InitLedger" (y/n)? ');
-    let fcn, args;
-    if (isInit === 'y') {
-      fcn = 'InitLedger';
-      args = [];
-    } else {
-      fcn = 'CreateAsset';
-      const assetId = `asset-${Math.floor(Math.random() * 1000000)}`;
-      console.log(`Generating a random asset ID to use to create a new asset: ${assetId}`);
-      args = [assetId, "yellow", "5", "Tom", "1300"];
-    }
-    // Initialize a set of asset data on the channel using the chaincode 'InitLedger' function.
-    console.log(`\n--> Submitting Transaction. fcn: ${fcn}, args: ${args}`);
-    await contract.submitTransaction(fcn, ...args);
-    console.log('*** Result: committed');
 
+    if (isInit === 'y') {
+      // Initialize ledger with demo assets
+      const fcn = 'InitLedger';
+      console.log(`--> Submitting Transaction. fcn: ${fcn}`);
+      await contract.submitTransaction(fcn);
+      console.log('*** Result: committed');
+    } else {
+      // Add an asset with a random id to the channel using the 'CreateAsset' chaincode function
+      let fcn = 'CreateAsset';
+      const assetId = `asset-${Math.floor(Math.random() * 1000000)}`;
+      console.log(`Adding new asset with following random asset ID to the ledger: ${assetId}`);
+      let args = [assetId, "yellow", "5", "Benny", "53000"];
+
+      console.log(`--> Submitting Transaction. fcn: ${fcn}, args: ${args}`);
+      await contract.submitTransaction(fcn, ...args);
+      console.log('*** Result: committed');
+
+      // Read just created asset from the channel using the 'ReadAsset' chaincode function
+      fcn = 'ReadAsset';
+      console.log(`Reading asset with ID: ${assetId}`);
+      args = [assetId];
+
+      console.log(`--> Evaluating Transaction. fcn: ${fcn}, args: ${args}`);
+      const blockchainResponse = await contract.evaluateTransaction(fcn, ...args);
+      console.log(`*** Result: ${blockchainResponse}`);
+    }
   } catch (error) {
 		console.error(`******** FAILED to run the application: ${error.stack ? error.stack : error}`);
 	} finally {

--- a/node.js/lib/kaleido.js
+++ b/node.js/lib/kaleido.js
@@ -21,8 +21,7 @@ class KaleidoClient {
         Authorization: `Bearer ${apiKey}`
       }
     };
-    const url = process.env.KALEIDO_URL || 'https://console.kaleido.io/api/v1';
-    this.kaleidoUrl = `${url}/api/v1`;
+    this.kaleidoUrl = process.env.KALEIDO_URL || 'https://console.kaleido.io/api/v1';
   }
 
   async init() {

--- a/node.js/lib/kaleido.js
+++ b/node.js/lib/kaleido.js
@@ -124,7 +124,7 @@ class KaleidoClient {
     let result = await axios.get(`${this.kaleidoUrl}/c/${consortiumId}/e/${environmentId}/channels`, this.apiAuth);
     let ret;
     if (result.data.length === 0) {
-      console.info(`No channels found in the environment ${environmentId}. The "default-channel" should have been created. Something went wrong in the environment. Exitting.`);
+      console.info(`No channels found in the environment ${environmentId}. The "default-channel" should have been created. Something went wrong in the environment. Exiting.`);
       process.exit(1);
     } else if (result.data.length > 1) {
       console.log('Found these channels:');


### PR DESCRIPTION
In commit 27a4db9ff3237466ce345d70b12c5a7d841f15a8, the README was changed to state that the default Kaleido API endpoint is `https://console.kaleido.io/api/v1`. This README change is correct, but this was already the case in the code before this commit. Nevertheless, `/api/v1` was added a second time in the commit 27a4db9ff3237466ce345d70b12c5a7d841f15a8.